### PR TITLE
Removing yarn.resourcemanager.hostname property

### DIFF
--- a/conf/yarn-site.xml
+++ b/conf/yarn-site.xml
@@ -27,10 +27,6 @@ under the License.
     <value>10</value>
   </property>
   <property>
-    <name>yarn.resourcemanager.hostname</name>
-    <value>127.0.0.1</value>
-  </property>
-  <property>
     <name>yarn.nodemanager.delete.debug-delay.sec</name>
     <value>86400</value>
   </property>


### PR DESCRIPTION
The yarn.resourcemanager.hostname is preventing the application from opening on localhost:8088. See https://github.com/apache/samza-hello-samza/pull/1

When the property is removed, the site works as expected:
![image](https://user-images.githubusercontent.com/11894889/89741697-0b045800-da59-11ea-983f-3174b1a69a3b.png)
